### PR TITLE
Change instantiation interface

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hpke (0.3.1)
+    hpke (1.0.0.pre.rc1)
       openssl (~> 3.3.0, >= 3.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -6,11 +6,26 @@ Hybrid Public Key Encryption (HPKE; [RFC 9180](https://datatracker.ietf.org/doc/
 
 ## Note
 
-This is still in very early development, so:
+This is tested against test vectors supplied by the authors of the RFC, but is not formally audited for security. Please be aware of this when using in production.
 
-- APIs are subject to change
-    - Especially the instantation interface of KEM and HPKE suite
-- This is tested against test vectors supplied by the authors of the RFC, but is not formally audited for security. Please be aware of this when using in production.
+### Breaking Changes in Version 1.0.0(-rc1)
+
+Previously, the instantiation of HPKE instance took four arguments, the curve for DHKEM, the hash function for DHKEM's HKDF, the hash function for the HKDF of HPKE, and the AEAD algorithm:
+
+```ruby
+hpke = HPKE.new(:x25519, :sha256, :sha256, :aes_128_gcm)
+```
+
+From 1.0.0, the instantiation of the HPKE instance will be done by passing algorithm identifiers (specified in the RFC, in Section 7.1, 7.2, and 7.3):
+
+```ruby
+hpke = HPKE.new(HPKE::DHKEM_X25519_HKDF_SHA256, HPKE::HKDF_SHA256, HPKE::AES_128_GCM)
+
+# also equivalent to:
+hpke = HPKE.new(0x0020, 0x0001, 0x0001)
+```
+
+The name of constants (and its values) are listed in the next section.
 
 ## Supported Features
 
@@ -22,20 +37,20 @@ Supports all modes, KEMs, AEAD functions in RFC 9180.
     - Auth
     - AuthPSK
 - Key Encapsulation Mechanisms (KEMs)
-    - DHKEM(P-256, HKDF-SHA256)
-    - DHKEM(P-384, HKDF-SHA384)
-    - DHKEM(P-521, HKDF-SHA512)
-    - DHKEM(X25519, HKDF-SHA256)
-    - DHKEM(X448, HKDF-SHA512)
+    - DHKEM(P-256, HKDF-SHA256) `DHKEM_P256_HKDF_SHA256` (= `0x0010`)
+    - DHKEM(P-384, HKDF-SHA384) `DHKEM_P384_HKDF_SHA384` (= `0x0011`)
+    - DHKEM(P-521, HKDF-SHA512) `DHKEM_P521_HKDF_SHA512` (= `0x0012`)
+    - DHKEM(X25519, HKDF-SHA256) `DHKEM_X25519_HKDF_SHA256` (= `0x0020`)
+    - DHKEM(X448, HKDF-SHA512) `DHKEM_X448_HKDF_SHA512` (= `0x0021`)
 - Key Derivation Functions (KDFs)
-    - HKDF-SHA256
-    - HKDF-SHA384
-    - HKDF-SHA512
+    - HKDF-SHA256 `HKDF_SHA256` (= `0x0001`)
+    - HKDF-SHA384 `HKDF_SHA384` (= `0x0002`)
+    - HKDF-SHA512 `HKDF_SHA512` (= `0x0003`)
 - AEAD Functions
-    - AES-128-GCM
-    - AES-256-GCM
-    - ChaCha20-Poly1305
-    - Export Only
+    - AES-128-GCM `AES_128_GCM` (= `0x0001`)
+    - AES-256-GCM `AES_256_GCM` (= `0x0002`)
+    - ChaCha20-Poly1305 `CHACHA20_POLY1305` (= `0x0003`)
+    - Export Only `EXPORT_ONLY`(= `0xffff`)
 
 ## Supported Environments
 
@@ -65,8 +80,8 @@ If bundler is not being used to manage dependencies, install the gem by executin
 # fourth parameter specifies the AEAD function
 
 # we will generate a different instance just for demonstration to show that nothing secret is stored in the HPKE suite instance
-hpke_s = HPKE.new(:x25519, :sha256, :sha256, :aes_128_gcm)
-hpke_r = HPKE.new(:x25519, :sha256, :sha256, :aes_128_gcm)
+hpke_s = HPKE.new(HPKE::DHKEM_X25519_HKDF_SHA256, HPKE::HKDF_SHA256, HPKE::AES_128_GCM)
+hpke_r = HPKE.new(HPKE::DHKEM_X25519_HKDF_SHA256, HPKE::HKDF_SHA256, HPKE::AES_128_GCM)
 
 # get a OpenSSL::PKey::PKey instance by either generating a key or loading a key from a PEM
 # see https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/PKey/PKey.html
@@ -98,14 +113,6 @@ ciphertext = context_s.seal('authentication_associated_data', 'plaintext')
 # then receiver decrypts the ciphertext
 context_r.open('authentication_associated_data', ciphertext)
 ```
-
-- Curve names (parameter 1)
-    - `:p_256`, `:p_384`, `:p_521`, `:x25519`, `:x448`
-        - Note: `:p_256` corresponds to `prime256v1`, `:p_384` corresponds to `secp384r1`, and `:p_521` corresponds to `secp521r1` in OpenSSL
-- Hash names (parameter 2 and 3)
-    - `:sha256`, `:sha384`, `:sha512`
-- AEAD function names (parameter 4)
-    - `:aes_128_gcm`, `:aes_256_gcm`, `:chacha20_poly1305`, `:export_only`
 
 ## Development
 

--- a/lib/hpke.rb
+++ b/lib/hpke.rb
@@ -9,7 +9,7 @@ require_relative './hpke/util'
 class HPKE
   include HPKE::Util
 
-  attr_reader :kem, :hkdf, :aead_name, :n_k, :n_n, :n_t
+  attr_reader :kem, :hkdf, :aead_id, :aead_name, :n_k, :n_n, :n_t
 
   # Algorithm Identifiers
   # DHKEM
@@ -41,38 +41,34 @@ class HPKE
   AVAILABLE_AEAD = [
     AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305, EXPORT_ONLY
   ]
+  CIPHERS = {
+    AES_128_GCM => {
+      name: 'aes-128-gcm',
+      n_k: 16,
+      n_n: 12,
+      n_t: 16
+    },
+    AES_256_GCM => {
+      name: 'aes-256-gcm',
+      n_k: 32,
+      n_n: 12,
+      n_t: 16
+    },
+    CHACHA20_POLY1305 => {
+      name: 'chacha20-poly1305',
+      n_k: 32,
+      n_n: 12,
+      n_t: 16
+    },
+    EXPORT_ONLY => {
+    }
+  }
 
   MODES = {
     base: 0x00,
     psk: 0x01,
     auth: 0x02,
     auth_psk: 0x03
-  }
-  CIPHERS = {
-    aes_128_gcm: {
-      name: 'aes-128-gcm',
-      aead_id: 0x0001,
-      n_k: 16,
-      n_n: 12,
-      n_t: 16
-    },
-    aes_256_gcm: {
-      name: 'aes-256-gcm',
-      aead_id: 0x0002,
-      n_k: 32,
-      n_n: 12,
-      n_t: 16
-    },
-    chacha20_poly1305: {
-      name: 'chacha20-poly1305',
-      aead_id: 0x0003,
-      n_k: 32,
-      n_n: 12,
-      n_t: 16
-    },
-    export_only: {
-      aead_id: 0xffff
-    }
   }
 
   def initialize(kem_id, kdf_id, aead_id)
@@ -92,12 +88,11 @@ class HPKE
              when HKDF_SHA512 then HKDF.new(HKDF_SHA512)
              else raise Exception.new('Unsupported KDF')
              end
-    cipher_name = CIPHERS.key(CIPHERS.find { |_, v| v[:aead_id] == aead_id }[1])
     @aead_id = aead_id
-    @aead_name = CIPHERS[cipher_name][:name]
-    @n_k = CIPHERS[cipher_name][:n_k]
-    @n_n = CIPHERS[cipher_name][:n_n]
-    @n_t = CIPHERS[cipher_name][:n_t]
+    @aead_name = CIPHERS[aead_id][:name]
+    @n_k = CIPHERS[aead_id][:n_k]
+    @n_n = CIPHERS[aead_id][:n_n]
+    @n_t = CIPHERS[aead_id][:n_t]
   end
 
   # public facing APIs
@@ -243,7 +238,7 @@ class HPKE
 
     secret = @hkdf.labeled_extract(shared_secret, 'secret', psk, suite_id)
 
-    unless @aead_id == CIPHERS[:export_only][:aead_id]
+    unless @aead_id == EXPORT_ONLY
       key = @hkdf.labeled_expand(secret, 'key', key_schedule_context, @n_k, suite_id)
       base_nonce = @hkdf.labeled_expand(secret, 'base_nonce', key_schedule_context, @n_n, suite_id)
     end
@@ -298,7 +293,7 @@ end
 
 class HPKE::ContextS < HPKE::Context
   def seal(aad, pt)
-    raise Exception.new('AEAD is export only') if @hpke.aead_name == :export_only
+    raise Exception.new('AEAD is export only') if @hpke.aead_id == HPKE::EXPORT_ONLY
 
     ct = @hpke.aead_encrypt(@key, compute_nonce(@sequence_number), aad, pt)
     increment_seq
@@ -308,7 +303,7 @@ end
 
 class HPKE::ContextR < HPKE::Context
   def open(aad, ct)
-    raise Exception.new('AEAD is export only') if @hpke.aead_name == :export_only
+    raise Exception.new('AEAD is export only') if @hpke.aead_id == HPKE::EXPORT_ONLY
 
     pt = @hpke.aead_decrypt(@key, compute_nonce(@sequence_number), aad, ct)
     # TODO: catch openerror then send out own openerror

--- a/lib/hpke.rb
+++ b/lib/hpke.rb
@@ -37,8 +37,9 @@ class HPKE
   AES_128_GCM = 0x0001
   AES_256_GCM = 0x0002
   CHACHA20_POLY1305 = 0x0003
+  EXPORT_ONLY = 0xffff
   AVAILABLE_AEAD = [
-    AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305
+    AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305, EXPORT_ONLY
   ]
 
   MODES = {
@@ -112,11 +113,12 @@ class HPKE
              when HKDF_SHA512 then HKDF.new(:sha512)
              else raise Exception.new('Unsupported KDF')
              end
-    @aead_name = CIPHERS.key(CIPHERS.find { |_, v| v[:aead_id] == aead_id }[1])
+    cipher_name = CIPHERS.key(CIPHERS.find { |_, v| v[:aead_id] == aead_id }[1])
     @aead_id = aead_id
-    @n_k = CIPHERS[@aead_name][:n_k]
-    @n_n = CIPHERS[@aead_name][:n_n]
-    @n_t = CIPHERS[@aead_name][:n_t]
+    @aead_name = CIPHERS[cipher_name][:name]
+    @n_k = CIPHERS[cipher_name][:n_k]
+    @n_n = CIPHERS[cipher_name][:n_n]
+    @n_t = CIPHERS[cipher_name][:n_t]
   end
 
   # public facing APIs

--- a/lib/hpke.rb
+++ b/lib/hpke.rb
@@ -11,6 +11,36 @@ class HPKE
 
   attr_reader :kem, :hkdf, :aead_name, :n_k, :n_n, :n_t
 
+  # Algorithm Identifiers
+  # DHKEM
+  # RFC 9180, Section 7.1 Table 2
+  DHKEM_P256_HKDF_SHA256 = 0x0010
+  DHKEM_P384_HKDF_SHA384 = 0x0011
+  DHKEM_P521_HKDF_SHA512 = 0x0012
+  DHKEM_X25519_HKDF_SHA256 = 0x0020
+  DHKEM_X448_HKDF_SHA512 = 0x0021
+  AVAILABLE_KEM = [
+    DHKEM_P256_HKDF_SHA256, DHKEM_P384_HKDF_SHA384, DHKEM_P521_HKDF_SHA512, DHKEM_X25519_HKDF_SHA256, DHKEM_X448_HKDF_SHA512
+  ]
+
+  # HKDF
+  # RFC 9180, Section 7.2, Table 3
+  HKDF_SHA256 = 0x0001
+  HKDF_SHA384 = 0x0002
+  HKDF_SHA512 = 0x0003
+  AVAILABLE_KDF = [
+    HKDF_SHA256, HKDF_SHA384, HKDF_SHA512
+  ]
+
+  # AEAD
+  # RFC 9180, Section 7.3, Table 5
+  AES_128_GCM = 0x0001
+  AES_256_GCM = 0x0002
+  CHACHA20_POLY1305 = 0x0003
+  AVAILABLE_AEAD = [
+    AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305
+  ]
+
   MODES = {
     base: 0x00,
     psk: 0x01,
@@ -65,17 +95,28 @@ class HPKE
     x448: DHKEM::X448
   }
 
-  def initialize(kem_curve_name, kem_hash, kdf_hash, aead_cipher)
-    raise Exception.new('Unsupported KEM curve name') if KEM_CURVES[kem_curve_name].nil?
-    raise Exception.new('Unsupported AEAD cipher name') if CIPHERS[aead_cipher].nil?
+  def initialize(kem_id, kdf_id, aead_id)
+    raise Exception.new('Unsupported AEAD') unless AVAILABLE_AEAD.include?(aead_id)
 
-    @kem = KEM_CURVES[kem_curve_name].new(kem_hash)
-    @hkdf = HKDF.new(kdf_hash)
-    @aead_name = CIPHERS[aead_cipher][:name]
-    @aead_id = CIPHERS[aead_cipher][:aead_id]
-    @n_k = CIPHERS[aead_cipher][:n_k]
-    @n_n = CIPHERS[aead_cipher][:n_n]
-    @n_t = CIPHERS[aead_cipher][:n_t]
+    @kem = case kem_id
+            when DHKEM_P256_HKDF_SHA256 then DHKEM::EC::P_256.new(:sha256)
+            when DHKEM_P384_HKDF_SHA384 then DHKEM::EC::P_384.new(:sha384)
+            when DHKEM_P521_HKDF_SHA512 then DHKEM::EC::P_521.new(:sha512)
+            when DHKEM_X25519_HKDF_SHA256 then DHKEM::X25519.new(:sha256)
+            when DHKEM_X448_HKDF_SHA512 then DHKEM::X448.new(:sha512)
+            else raise Exception.new('Unsupported KEM')
+            end
+    @hkdf = case kdf_id
+             when HKDF_SHA256 then HKDF.new(:sha256)
+             when HKDF_SHA384 then HKDF.new(:sha384)
+             when HKDF_SHA512 then HKDF.new(:sha512)
+             else raise Exception.new('Unsupported KDF')
+             end
+    @aead_name = CIPHERS.key(CIPHERS.find { |_, v| v[:aead_id] == aead_id }[1])
+    @aead_id = aead_id
+    @n_k = CIPHERS[@aead_name][:n_k]
+    @n_n = CIPHERS[@aead_name][:n_n]
+    @n_t = CIPHERS[@aead_name][:n_t]
   end
 
   # public facing APIs

--- a/lib/hpke.rb
+++ b/lib/hpke.rb
@@ -100,17 +100,17 @@ class HPKE
     raise Exception.new('Unsupported AEAD') unless AVAILABLE_AEAD.include?(aead_id)
 
     @kem = case kem_id
-            when DHKEM_P256_HKDF_SHA256 then DHKEM::EC::P_256.new(:sha256)
-            when DHKEM_P384_HKDF_SHA384 then DHKEM::EC::P_384.new(:sha384)
-            when DHKEM_P521_HKDF_SHA512 then DHKEM::EC::P_521.new(:sha512)
-            when DHKEM_X25519_HKDF_SHA256 then DHKEM::X25519.new(:sha256)
-            when DHKEM_X448_HKDF_SHA512 then DHKEM::X448.new(:sha512)
+            when DHKEM_P256_HKDF_SHA256 then DHKEM::EC::P_256.new(HKDF_SHA256)
+            when DHKEM_P384_HKDF_SHA384 then DHKEM::EC::P_384.new(HKDF_SHA384)
+            when DHKEM_P521_HKDF_SHA512 then DHKEM::EC::P_521.new(HKDF_SHA512)
+            when DHKEM_X25519_HKDF_SHA256 then DHKEM::X25519.new(HKDF_SHA256)
+            when DHKEM_X448_HKDF_SHA512 then DHKEM::X448.new(HKDF_SHA512)
             else raise Exception.new('Unsupported KEM')
             end
     @hkdf = case kdf_id
-             when HKDF_SHA256 then HKDF.new(:sha256)
-             when HKDF_SHA384 then HKDF.new(:sha384)
-             when HKDF_SHA512 then HKDF.new(:sha512)
+             when HKDF_SHA256 then HKDF.new(HKDF_SHA256)
+             when HKDF_SHA384 then HKDF.new(HKDF_SHA384)
+             when HKDF_SHA512 then HKDF.new(HKDF_SHA512)
              else raise Exception.new('Unsupported KDF')
              end
     cipher_name = CIPHERS.key(CIPHERS.find { |_, v| v[:aead_id] == aead_id }[1])

--- a/lib/hpke.rb
+++ b/lib/hpke.rb
@@ -74,27 +74,6 @@ class HPKE
       aead_id: 0xffff
     }
   }
-  HASHES = {
-    sha256: {
-      name: 'SHA256',
-      kdf_id: 1
-    },
-    sha384: {
-      name: 'SHA384',
-      kdf_id: 2
-    },
-    sha512: {
-      name: 'SHA512',
-      kdf_id: 3
-    }
-  }
-  KEM_CURVES = {
-    p_256: DHKEM::EC::P_256,
-    p_384: DHKEM::EC::P_384,
-    p_521: DHKEM::EC::P_521,
-    x25519: DHKEM::X25519,
-    x448: DHKEM::X448
-  }
 
   def initialize(kem_id, kdf_id, aead_id)
     raise Exception.new('Unsupported AEAD') unless AVAILABLE_AEAD.include?(aead_id)

--- a/lib/hpke/dhkem.rb
+++ b/lib/hpke/dhkem.rb
@@ -6,8 +6,11 @@ require_relative 'util'
 class HPKE::DHKEM
   include HPKE::Util
 
-  def initialize(hash_name)
-    @hkdf = HPKE::HKDF.new(hash_name)
+  def initialize(kdf_id)
+    # Currently all KDFs are HKDF so this works fine,
+    # but when other KDFs are added, this should be fixed
+    @hkdf = HPKE::HKDF.new(kdf_id)
+    raise Exception.new('KDF not compatible with DHKEM curve') unless @hkdf.n_h == self.n_secret
   end
 
   def encap(pk_r)

--- a/lib/hpke/hkdf.rb
+++ b/lib/hpke/hkdf.rb
@@ -52,39 +52,3 @@ class HPKE::HKDF
     expand(prk, labeled_info, l)
   end
 end
-
-class HPKE::HKDF::HMAC_SHA256 < HPKE::HKDF
-  private
-
-  def digest_algorithm
-    'SHA256'
-  end
-
-  def kdf_id
-    1
-  end
-end
-
-class HPKE::HKDF::HMAC_SHA384 < HPKE::HKDF
-  private
-
-  def digest_algorithm
-    'SHA384'
-  end
-
-  def kdf_id
-    2
-  end
-end
-
-class HPKE::HKDF::HMAC_SHA512 < HPKE::HKDF
-  private
-  
-  def digest_algorithm
-    'SHA512'
-  end
-
-  def kdf_id
-    3
-  end
-end

--- a/lib/hpke/hkdf.rb
+++ b/lib/hpke/hkdf.rb
@@ -6,32 +6,22 @@ class HPKE::HKDF
 
   attr_reader :kdf_id
 
-  ALGORITHMS = {
-    sha256: {
-      name: 'SHA256',
-      kdf_id: 1
-    },
-    sha384: {
-      name: 'SHA384',
-      kdf_id: 2
-    },
-    sha512: {
-      name: 'SHA512',
-      kdf_id: 3
-    }
-  }
-
   def n_h
     @digest.digest_length
   end
 
-  def initialize(alg_name)
-    if algorithm = ALGORITHMS[alg_name]
-      @digest = OpenSSL::Digest.new(algorithm[:name])
-      @kdf_id = algorithm[:kdf_id]
+  def initialize(kdf_id)
+    case kdf_id
+    when HPKE::HKDF_SHA256
+      @digest = OpenSSL::Digest.new('SHA256')
+    when HPKE::HKDF_SHA384
+      @digest = OpenSSL::Digest.new('SHA384')
+    when HPKE::HKDF_SHA512
+      @digest = OpenSSL::Digest.new('SHA512')
     else
       raise Exception.new('Unknown hash algorithm')
     end
+    @kdf_id = kdf_id
   end
 
   def hmac(key, data)

--- a/lib/hpke/version.rb
+++ b/lib/hpke/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class HPKE
-  VERSION = "0.3.1"
+  VERSION = "1.0.0-rc1"
 end

--- a/spec/dhkem_spec.rb
+++ b/spec/dhkem_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe HPKE::DHKEM do
           ikme = ['4270e54ffd08d79d5928020af4686d8f6b7d35dbe470265f1f5aa22816ce860e'].pack('H*')
           pkem = '04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4'
   
-          dhkem = HPKE::DHKEM::EC::P_256.new(:sha256)
+          dhkem = HPKE::DHKEM::EC::P_256.new(HPKE::HKDF_SHA256)
           pkey = dhkem.derive_key_pair(ikme)
           expect(dhkem.serialize_public_key(pkey).unpack1('H*')).to eq(pkem)
         end
@@ -23,7 +23,7 @@ RSpec.describe HPKE::DHKEM do
           ikme = ['7f06ab8215105fc46aceeb2e3dc5028b44364f960426eb0d8e4026c2f8b5d7e7a986688f1591abf5ab753c357a5d6f0440414b4ed4ede71317772ac98d9239f70904'].pack('H*')
           pkem = '040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0'
   
-          dhkem = HPKE::DHKEM::EC::P_521.new(:sha512)
+          dhkem = HPKE::DHKEM::EC::P_521.new(HPKE::HKDF_SHA512)
           pkey = dhkem.derive_key_pair(ikme)
           expect(dhkem.serialize_public_key(pkey).unpack1('H*')).to eq(pkem)
         end
@@ -35,7 +35,7 @@ RSpec.describe HPKE::DHKEM do
           ikme = ['7268600d403fce431561aef583ee1613527cff655c1343f29812e66706df3234'].pack('H*')
           pkem = '37fda3567bdbd628e88668c3c8d7e97d1d1253b6d4ea6d44c150f741f1bf4431'
   
-          dhkem = HPKE::DHKEM::X25519.new(:sha256)
+          dhkem = HPKE::DHKEM::X25519.new(HPKE::HKDF_SHA256)
           pkey = dhkem.derive_key_pair(ikme)
           expect(dhkem.serialize_public_key(pkey).unpack1('H*')).to eq(pkem)
         end
@@ -45,7 +45,7 @@ RSpec.describe HPKE::DHKEM do
     context "create_key_pair_from_secret" do
       context "for X25519" do
         it "creates OpenSSL::PKey::PKey instance" do
-          dhkem = HPKE::DHKEM::X25519.new(:sha256)
+          dhkem = HPKE::DHKEM::X25519.new(HPKE::HKDF_SHA256)
   
           pkey = dhkem.create_key_pair_from_secret(SecureRandom.random_bytes(32))
           expect(pkey).to be_an_instance_of(OpenSSL::PKey::PKey)
@@ -54,7 +54,7 @@ RSpec.describe HPKE::DHKEM do
   
       context "for X448" do
         it "creates OpenSSL::PKey::PKey instance" do
-          dhkem = HPKE::DHKEM::X448.new(:sha512)
+          dhkem = HPKE::DHKEM::X448.new(HPKE::HKDF_SHA512)
   
           pkey = dhkem.create_key_pair_from_secret(SecureRandom.random_bytes(56))
           expect(pkey).to be_an_instance_of(OpenSSL::PKey::PKey)

--- a/spec/hkdf_spec.rb
+++ b/spec/hkdf_spec.rb
@@ -3,21 +3,21 @@
 RSpec.describe HPKE::HKDF do
   context "Instantiation" do
     it "instantiates with SHA-256" do
-      expect(HPKE::HKDF.new(:sha256)).to be_an_instance_of(HPKE::HKDF)
+      expect(HPKE::HKDF.new(HPKE::HKDF_SHA256)).to be_an_instance_of(HPKE::HKDF)
     end
 
     it "instantiates with SHA-384" do
-      expect(HPKE::HKDF.new(:sha384)).to be_an_instance_of(HPKE::HKDF)
+      expect(HPKE::HKDF.new(HPKE::HKDF_SHA384)).to be_an_instance_of(HPKE::HKDF)
     end
 
     it "instantiates with SHA-512" do
-      expect(HPKE::HKDF.new(:sha512)).to be_an_instance_of(HPKE::HKDF)
+      expect(HPKE::HKDF.new(HPKE::HKDF_SHA512)).to be_an_instance_of(HPKE::HKDF)
     end
   end
 
   context "Extract and Expand" do
     it "passes Test Case 1 in RFC 5869" do
-      hkdf = HPKE::HKDF.new(:sha256)
+      hkdf = HPKE::HKDF.new(HPKE::HKDF_SHA256)
       ikm = ['0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b'].pack('H*')
       salt = ['000102030405060708090a0b0c'].pack('H*')
       info = ['f0f1f2f3f4f5f6f7f8f9'].pack('H*')
@@ -34,7 +34,7 @@ RSpec.describe HPKE::HKDF do
     end
 
     it "passes Test Case 2 in RFC 5869" do
-      hkdf = HPKE::HKDF.new(:sha256)
+      hkdf = HPKE::HKDF.new(HPKE::HKDF_SHA256)
       ikm = ['000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f'].pack('H*')
       salt = ['606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf'].pack('H*')
       info = ['b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff'].pack('H*')
@@ -51,7 +51,7 @@ RSpec.describe HPKE::HKDF do
     end
 
     it "passes Test Case 3 in RFC 5869" do
-      hkdf = HPKE::HKDF.new(:sha256)
+      hkdf = HPKE::HKDF.new(HPKE::HKDF_SHA256)
       ikm = ['0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b'].pack('H*')
       salt = [''].pack('H*')
       info = [''].pack('H*')

--- a/spec/hpke_spec.rb
+++ b/spec/hpke_spec.rb
@@ -28,15 +28,15 @@ RSpec.describe HPKE do
   test_vectors.each do |vec|
     context "mode #{vec['mode']}, DHKEM(#{KEMS[vec['kem_id']][0]}, #{KEMS[vec['kem_id']][1]}), HKDF(#{KDFS[vec['kdf_id']]}), #{AEAD_CIPHERS[vec['aead_id']]}" do
       it "instantiates a HPKE instance" do
-        hpke = HPKE.new(KEMS[vec['kem_id']][0], KEMS[vec['kem_id']][1], KDFS[vec['kdf_id']], AEAD_CIPHERS[vec['aead_id']])
+        hpke = HPKE.new(vec['kem_id'], vec['kdf_id'], vec['aead_id'])
         expect(hpke).to be_an_instance_of(HPKE)
       end
 
       context "DHKEM(#{KEMS[vec['kem_id']][0]}, #{KEMS[vec['kem_id']][1]})" do
         it "derives key pair as expected" do
-          ikme = [vec['ikmE']].pack('H*')
+          # ikme = [vec['ikmE']].pack('H*')
           ikmr = [vec['ikmR']].pack('H*')
-          hpke = HPKE.new(KEMS[vec['kem_id']][0], KEMS[vec['kem_id']][1], KDFS[vec['kdf_id']], AEAD_CIPHERS[vec['aead_id']])
+          hpke = HPKE.new(vec['kem_id'], vec['kdf_id'], vec['aead_id'])
           pkey_r = hpke.kem.derive_key_pair(ikmr)
           expect(hpke.kem.serialize_public_key(pkey_r).unpack1('H*')).to eq(vec['pkRm'])
         end
@@ -47,7 +47,7 @@ RSpec.describe HPKE do
           info = [vec['info']].pack('H*')
           ikme = [vec['ikmE']].pack('H*')
           ikmr = [vec['ikmR']].pack('H*')
-          hpke = HPKE.new(KEMS[vec['kem_id']][0], KEMS[vec['kem_id']][1], KDFS[vec['kdf_id']], AEAD_CIPHERS[vec['aead_id']])
+          hpke = HPKE.new(vec['kem_id'], vec['kdf_id'], vec['aead_id'])
           pkey_r = hpke.kem.derive_key_pair(ikmr)
           encap_result = case vec['mode']
           when 0
@@ -81,7 +81,7 @@ RSpec.describe HPKE do
         it "decapsulates as expected" do
           info = [vec['info']].pack('H*')
           ikmr = [vec['ikmR']].pack('H*')
-          hpke = HPKE.new(KEMS[vec['kem_id']][0], KEMS[vec['kem_id']][1], KDFS[vec['kdf_id']], AEAD_CIPHERS[vec['aead_id']])
+          hpke = HPKE.new(vec['kem_id'], vec['kdf_id'], vec['aead_id'])
           pkey_r = hpke.kem.derive_key_pair(ikmr)
           enc = [vec['enc']].pack('H*') 
           
@@ -110,7 +110,7 @@ RSpec.describe HPKE do
         end
 
         it "encrypts as expected" do
-          hpke = HPKE.new(KEMS[vec['kem_id']][0], KEMS[vec['kem_id']][1], KDFS[vec['kdf_id']], AEAD_CIPHERS[vec['aead_id']])
+          hpke = HPKE.new(vec['kem_id'], vec['kdf_id'], vec['aead_id'])
 
           info = [vec['info']].pack('H*')
           ikme = [vec['ikmE']].pack('H*')


### PR DESCRIPTION
This changes the instantiation interface

- from specifying each algorithm with a symbol
- to specifying KEM_ID, KDF_ID, AEAD_ID as specified in the RFC.

The IDs can be specified with the integer value written in the RFC, or through constants written under the HPKE class namespace.