### PR TITLE
feat: HPKE#setup_base_s, setup_psk_s, setup_auth_s and setup_auth_psk_s return shared_secret

### DIFF
--- a/lib/hpke.rb
+++ b/lib/hpke.rb
@@ -100,7 +100,8 @@ class HPKE
     encap_result = @kem.encap(pk_r)
     {
       enc: encap_result[:enc],
-      context_s: key_schedule_s(MODES[:base], encap_result[:shared_secret], info, DEFAULT_PSK, DEFAULT_PSK_ID)
+      context_s: key_schedule_s(MODES[:base], encap_result[:shared_secret], info, DEFAULT_PSK, DEFAULT_PSK_ID),
+      shared_secret: encap_result[:shared_secret]
     }
   end
 
@@ -113,7 +114,8 @@ class HPKE
     encap_result = @kem.encap(pk_r)
     {
       enc: encap_result[:enc],
-      context_s: key_schedule_s(MODES[:psk], encap_result[:shared_secret], info, psk, psk_id)
+      context_s: key_schedule_s(MODES[:psk], encap_result[:shared_secret], info, psk, psk_id),
+      shared_secret: encap_result[:shared_secret]
     }
   end
 
@@ -126,7 +128,8 @@ class HPKE
     encap_result = @kem.auth_encap(pk_r, sk_s)
     {
       enc: encap_result[:enc],
-      context_s: key_schedule_s(MODES[:auth], encap_result[:shared_secret], info, DEFAULT_PSK, DEFAULT_PSK_ID)
+      context_s: key_schedule_s(MODES[:auth], encap_result[:shared_secret], info, DEFAULT_PSK, DEFAULT_PSK_ID),
+      shared_secret: encap_result[:shared_secret]
     }
   end
 
@@ -139,7 +142,8 @@ class HPKE
     encap_result = @kem.auth_encap(pk_r, sk_s)
     {
       enc: encap_result[:enc],
-      context_s: key_schedule_s(MODES[:auth_psk], encap_result[:shared_secret], info, psk, psk_id)
+      context_s: key_schedule_s(MODES[:auth_psk], encap_result[:shared_secret], info, psk, psk_id),
+      shared_secret: encap_result[:shared_secret]
     }
   end
 
@@ -153,7 +157,8 @@ class HPKE
     encap_result = @kem.encap_fixed(pk_r, ikm_e)
     {
       enc: encap_result[:enc],
-      context_s: key_schedule_s(MODES[:base], encap_result[:shared_secret], info, DEFAULT_PSK, DEFAULT_PSK_ID)
+      context_s: key_schedule_s(MODES[:base], encap_result[:shared_secret], info, DEFAULT_PSK, DEFAULT_PSK_ID),
+      shared_secret: encap_result[:shared_secret]
     }
   end
 
@@ -161,7 +166,8 @@ class HPKE
     encap_result = @kem.encap_fixed(pk_r, ikm_e)
     {
       enc: encap_result[:enc],
-      context_s: key_schedule_s(MODES[:psk], encap_result[:shared_secret], info, psk, psk_id)
+      context_s: key_schedule_s(MODES[:psk], encap_result[:shared_secret], info, psk, psk_id),
+      shared_secret: encap_result[:shared_secret]
     }
   end
 
@@ -169,7 +175,8 @@ class HPKE
     encap_result = @kem.auth_encap_fixed(pk_r, sk_s, ikm_e)
     {
       enc: encap_result[:enc],
-      context_s: key_schedule_s(MODES[:auth], encap_result[:shared_secret], info, DEFAULT_PSK, DEFAULT_PSK_ID)
+      context_s: key_schedule_s(MODES[:auth], encap_result[:shared_secret], info, DEFAULT_PSK, DEFAULT_PSK_ID),
+      shared_secret: encap_result[:shared_secret]
     }
   end
 
@@ -177,7 +184,8 @@ class HPKE
     encap_result = @kem.auth_encap_fixed(pk_r, sk_s, ikm_e)
     {
       enc: encap_result[:enc],
-      context_s: key_schedule_s(MODES[:auth_psk], encap_result[:shared_secret], info, psk, psk_id)
+      context_s: key_schedule_s(MODES[:auth_psk], encap_result[:shared_secret], info, psk, psk_id),
+      shared_secret: encap_result[:shared_secret]
     }
   end
 

--- a/spec/hpke_spec.rb
+++ b/spec/hpke_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe HPKE do
             hpke.setup_auth_psk_s_fixed(pkey_r, info, psk, psk_id, pkey_s, ikme)
           end
           expect(encap_result[:enc].unpack1('H*')).to eq(vec['enc'])
+          expect(encap_result[:shared_secret].unpack1('H*')).to eq(vec['shared_secret'])
 
           context_s = encap_result[:context_s]
 


### PR DESCRIPTION
Hi!
This PR is related to https://github.com/sylph01/hpke-rb/issues/3#issuecomment-3602341963 .

I propose that `HPKE#setup_base_s`, `HPKE#setup_psk_s`, `HPKE#setup_auth_s` and `HPKE#setup_auth_psk_s` return the `:shared_secret`.