### PR TITLE
chore: update openssl dependency to support v4.0.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: .
   specs:
     hpke (1.0.0)
-      openssl (~> 3.3.0, >= 3.0)
+      openssl (~> 4.0.0, >= 3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.5.0)
-    openssl (3.3.0)
+    openssl (4.0.1)
     ostruct (0.6.3)
     rake (13.0.6)
     rspec (3.12.0)
@@ -27,6 +27,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/hpke.gemspec
+++ b/hpke.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "openssl", "~> 3.3.0", ">= 3.0"
+  spec.add_dependency "openssl", "~> 4.0.0", ">= 3.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Hi, thank you for maintaining this gem!

I would like to propose relaxing the openssl dependency constraint. Currently the gemspec pins it to:

https://github.com/sylph01/hpke-rb/blob/00e38a31bf42a1add3be285a07a0391f38d73b78/hpke.gemspec#L32

This prevents users from adopting openssl 4.0.x, which was released in 2025/12. I reviewed the [v4.0.0](https://github.com/ruby/openssl/releases/tag/v4.0.0) and [v4.0.1](https://github.com/ruby/openssl/releases/tag/v4.0.1) release notes and found no breaking changes that affect hpke-rb.

I updated it to "~> 4.0.0", ">= 3.0".